### PR TITLE
feat(utils): print hid devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ All files are available in [latest release](https://github.com/zzeneg/qmk-hid-ho
 Default configuration is set to [stront](https://github.com/zzeneg/stront). For other keyboards you need to modify the configuration file (`qmk-hid-host.json`).
 
 - `devices` section contains a list of keyboards
-  - `productId` - `pid` from your keyboard's `info.json`
+  - `productId` - `pid` from your keyboard's `info.json`. You can get it by running `qmk-hid-host -p`
   - `name` - keyboard's name (optional, visible only in logs)
   - `usage` and `usagePage` - optional, override only if `RAW_USAGE_ID` and `RAW_USAGE_PAGE` were redefined in firmware
 - `layouts` - list of supported keyboard layouts in two-letter format (app sends layout's index, not name)
@@ -162,7 +162,7 @@ When you verified that the application works with your keyboard, you can use `qm
         `./qmk-hid-host -c ~/Downloads/macos/qmk-hid-host.json`
    
 5. If you `qmk-hid-host` stuck at `Waiting for keyboard...` there are two common mistakes:
-   1. You're wrong with productId in your config
+   1. You're wrong with productId in your config. Check `qmk-hid-host -p`
    2. Close Vial app and try again
 
 ## Development

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,12 @@ mod config;
 mod data_type;
 mod keyboard;
 mod providers;
+mod utils;
 
 use config::load_config;
 use keyboard::Keyboard;
 use providers::{_base::Provider, layout::LayoutProvider, relay::RelayProvider, time::TimeProvider, volume::VolumeProvider};
+use utils::print_hids::print_unique_hid_devices;
 use tokio::sync::{broadcast, mpsc};
 
 #[cfg(not(target_os = "macos"))]
@@ -26,6 +28,9 @@ struct Args {
     /// Path to the configuration file
     #[arg(short, long)]
     config: Option<std::path::PathBuf>,
+    /// Print all connected HIDs
+    #[arg(short, long)]
+    print_hids: bool
 }
 
 fn main() {
@@ -40,6 +45,9 @@ fn main() {
     let (device_to_host_sender, _) = broadcast::channel::<Vec<u8>>(1);
 
     let args = Args::parse();
+    if args.print_hids {
+        return print_unique_hid_devices();
+    }
     let config = load_config(args.config.unwrap_or("./qmk-hid-host.json".into()));
     let reconnect_delay = config.reconnect_delay.unwrap_or(5000);
     for device in &config.devices {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,1 @@
+pub mod print_hids;

--- a/src/utils/print_hids.rs
+++ b/src/utils/print_hids.rs
@@ -1,0 +1,33 @@
+use tracing::info;
+use std::collections::HashSet;
+use hidapi::HidApi;
+
+pub fn print_unique_hid_devices() {
+    let api = HidApi::new().unwrap();
+    let mut seen = HashSet::new();
+
+    info!("Enumerating unique HID devices...");
+
+    for dev in api.device_list() {
+        let product_name = dev.product_string().unwrap_or_default().to_string();
+        let key = (dev.vendor_id(), dev.product_id(), product_name.clone());
+
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+
+        if dev.product_id() == 0 || product_name.is_empty() {
+            continue;
+        }
+
+        info!(
+            "HID: VID={:04x}, PID={:04x}, usage_page={:?}, usage={:?}, productId=0x{:04x} product={:?}",
+            dev.vendor_id(),
+            dev.product_id(),
+            dev.usage_page(),
+            dev.usage(),
+            dev.product_id(),
+            product_name
+        );
+    }
+}


### PR DESCRIPTION
Print all connected HIDs. Example output: 

```
$ ./target/debug/qmk-hid-host -p
2025-10-25T09:28:11.857168Z  INFO qmk_hid_host::utils::print_hids: Enumerating unique HID devices...
2025-10-25T09:28:11.857888Z  INFO qmk_hid_host::utils::print_hids: HID: VID=05ac, PID=8600, usage_page=1, usage=6, productId=0x8600 product="TouchBarUserDevice"
2025-10-25T09:28:11.857904Z  INFO qmk_hid_host::utils::print_hids: HID: VID=004c, PID=0265, usage_page=65280, usage=18, productId=0x0265 product="Nikita’s Magic Trackpad"
2025-10-25T09:28:11.857933Z  INFO qmk_hid_host::utils::print_hids: HID: VID=05ac, PID=0341, usage_page=65280, usage=11, productId=0x0341 product="Apple Internal Keyboard / Trackpad"
2025-10-25T09:28:11.857973Z  INFO qmk_hid_host::utils::print_hids: HID: VID=e126, PID=0070, usage_page=1, usage=2, productId=0x0070 product="K:03 v3"
2025-10-25T09:28:11.857989Z  INFO qmk_hid_host::utils::print_hids: HID: VID=05ac, PID=0341, usage_page=65280, usage=15, productId=0x0341 product="Keyboard Backlight"
```